### PR TITLE
Couple small changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN mkdir -p '/mnt/src' && \
     mkdir -p /build && \
     groupadd -g 1000 builduser && \
     useradd -r -u 1000 -g builduser -d /home/builduser -m builduser && \
+    sed 's/main$/main contrib/' /etc/apt/sources.list && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get -y install build-essential devscripts wget && \

--- a/buildpackage
+++ b/buildpackage
@@ -41,7 +41,7 @@ function export_package() {
 
 export DEBIAN_FRONTEND=noninteractive
 create_local_debian_repo
-import_source
-install_build_dependencies
-build_package
+import_source || exit 1
+install_build_dependencies || exit 1
+build_package || exit 1
 export_package


### PR DESCRIPTION
buildpackage should exit if any command fails.
enable contrib component of the debian package repo. (Our OBS uses main and contib). Not sure if this will help, but good to do for consistency. I've not figured out how have danos-buildpackage use a Docker image I generate locally for testing and experimentation. Is this possible?